### PR TITLE
Add logging/remove global router-id

### DIFF
--- a/roles/ibgp/templates/quagga_config.j2
+++ b/roles/ibgp/templates/quagga_config.j2
@@ -4,8 +4,7 @@
 {% set loopback_ip = intvars.loopback -%}
 {% set swbridges = intvars.bridges -%}
 
-!
-router-id {{ loopback_ip }}
+log file /var/log/quagga/quagga.log
 !
 {% if bgpvars is defined -%}
 router bgp {{ bgpvars.myasn }}


### PR DESCRIPTION
Added a log file directive to the config and also removed the global router-id.  The global router-id is not needed.